### PR TITLE
Add files via upload

### DIFF
--- a/SWTG/custom/cards/SWTG/a/a-wing.txt
+++ b/SWTG/custom/cards/SWTG/a/a-wing.txt
@@ -6,8 +6,7 @@ PT:2/2
 K:Haste
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/a/aat-1.txt
+++ b/SWTG/custom/cards/SWTG/a/aat-1.txt
@@ -10,8 +10,7 @@ SVar:DBGainLife:DB$ GainLife | Defined$ You | LifeAmount$ 1
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put four repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 4 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed from this card, you may cast it until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/a/armed_protocol_droid.txt
+++ b/SWTG/custom/cards/SWTG/a/armed_protocol_droid.txt
@@ -8,8 +8,7 @@ SVar:TrigDebuff:DB$ Pump | ValidTgts$ Creature.nonArtifact | TgtPrompt$ Select t
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put three repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 3 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed from this card, you may cast it until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/c/c_3po_and_r2d2.txt
+++ b/SWTG/custom/cards/SWTG/c/c_3po_and_r2d2.txt
@@ -9,8 +9,7 @@ SVar:DBDraw:DB$ Draw | NumCards$ 1 | Defined$ You
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put two repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 2 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed from this card, you may cast it until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/c/corellian_corvette.txt
+++ b/SWTG/custom/cards/SWTG/c/corellian_corvette.txt
@@ -4,8 +4,7 @@ Types:Artifact Creature Starship
 PT:3/3
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/d/dark_trooper.txt
+++ b/SWTG/custom/cards/SWTG/d/dark_trooper.txt
@@ -5,8 +5,7 @@ PT:2/2
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put two repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 2 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter. When the last is removed, you may cast it from your graveyard until end of turn.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter. When the last is removed, you may cast it from your graveyard until end of turn.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed from this card, you may cast it until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/d/droid_commando.txt
+++ b/SWTG/custom/cards/SWTG/d/droid_commando.txt
@@ -9,8 +9,7 @@ SVar:DBGains:DB$ GainLife | Defined$ You | LifeAmount$ 2
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put three repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 3 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter. When the last is removed, you may cast CARDNAME until end of turn.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter. When the last is removed, you may cast CARDNAME until end of turn.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed, you may cast CARDNAME until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/d/droideka.txt
+++ b/SWTG/custom/cards/SWTG/d/droideka.txt
@@ -7,8 +7,7 @@ A:AB$ ChangeTargets | Cost$ 2 U | TargetType$ Spell,Activated,Triggered | ValidT
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put three repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 3 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed, you may cast CARDNAME until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/i/ig-88b.txt
+++ b/SWTG/custom/cards/SWTG/i/ig-88b.txt
@@ -11,8 +11,7 @@ SVar:X:Count$Valid Creature.ControlledBy TriggeredTarget$CardCounters.BOUNTY
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put three repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 3 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter. When the last is removed, you may cast CARDNAME until end of turn.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter. When the last is removed, you may cast CARDNAME until end of turn.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed, you may cast this card from your graveyard until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/j/jedi_knight.txt
+++ b/SWTG/custom/cards/SWTG/j/jedi_knight.txt
@@ -1,6 +1,6 @@
 Name:Jedi Knight
 ManaCost:G W U
-Types:Creature Human Jedi
+Types:Creature Human Jedi Knight
 PT:3/3
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Any | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigBounce | TriggerDescription$ When Jedi Knight leaves the battlefield, return target nonland permanent you don't control to its owner's hand.

--- a/SWTG/custom/cards/SWTG/j/jedi_starfighter.txt
+++ b/SWTG/custom/cards/SWTG/j/jedi_starfighter.txt
@@ -4,8 +4,7 @@ Types:Artifact Creature Jedi Starship
 PT:2/2
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/j/jungle_village.txt
+++ b/SWTG/custom/cards/SWTG/j/jungle_village.txt
@@ -6,4 +6,4 @@ A:AB$ Mana | Cost$ T | Produced$ C | SpellDescription$ Add {C}.
 
 A:AB$ ChangeZone | Cost$ T Sac<1/CARDNAME> | Origin$ Library | Destination$ Battlefield | Tapped$ True | ChangeType$ Land.Mountain+Basic,Land.Forest+Basic,Land.Plains+Basic | ChangeNum$ 1 | SpellDescription$ Search your library for a basic Mountain, Forest, or Plains card and put it onto the battlefield tapped, then shuffle.
 
-Oracle:{T}: Add {C}.\n{T}, Sacrifice Underworld Slums: Search your library for a basic Mountain, Forest, or Plains card and put it onto the battlefield tapped. Then shuffle.
+Oracle:{T}: Add {C}.\n{T}, Sacrifice Jungle Village: Search your library for a basic Mountain, Forest, or Plains card and put it onto the battlefield tapped. Then shuffle.

--- a/SWTG/custom/cards/SWTG/l/laat_gunship.txt
+++ b/SWTG/custom/cards/SWTG/l/laat_gunship.txt
@@ -7,8 +7,7 @@ T:Mode$ Attacks | ValidCard$ Card.Self | Execute$ TrigToken | TriggerDescription
 SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ w_1_1_trooper | TokenTapped$ True | TokenAttacking$ True | TokenOwner$ You
 
 A:AB$ Pump | Cost$ W | SorcerySpeed$ True | KW$ Spaceflight | SpellDescription$ CARDNAME gains spaceflight until end of turn. Activate only as a sorcery.
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/l/lightsaber.txt
+++ b/SWTG/custom/cards/SWTG/l/lightsaber.txt
@@ -8,4 +8,4 @@ K:Equip:3
 
 S:Mode$ ReduceCost | ValidTarget$ Creature.Jedi,Creature.Sith | ValidSpell$ Activated.Equip | Amount$ 2 | ValidCard$ Card.Self | Description$ CARDNAME's equip ability costs {1} if it targets a Jedi or Sith.
 
-Oracle:Equipped creature gets +1/+0 and has first strike.\nEquip {3}\nUnderworld Slums' equip ability costs {1} if it targets a Jedi or Sith.
+Oracle:Equipped creature gets +1/+0 and has first strike.\nEquip {3}\nLightsaber's equip ability costs {1} if it targets a Jedi or Sith.

--- a/SWTG/custom/cards/SWTG/m/maintenance_droid.txt
+++ b/SWTG/custom/cards/SWTG/m/maintenance_droid.txt
@@ -10,8 +10,7 @@ SVar:RemoveRepair:DB$ RemoveCounter | Defined$ Remembered | CounterType$ REPAIR 
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put four repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 4 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed, you may cast CARDNAME until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/m/maintenance_hangaar.txt
+++ b/SWTG/custom/cards/SWTG/m/maintenance_hangaar.txt
@@ -2,19 +2,15 @@ Name:Maintenance Hangar
 ManaCost:2 W
 Types:Enchantment
 
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigRemove | TriggerDescription$ At the beginning of your upkeep, remove an additional repair counter from each card in your graveyard.
-SVar:TrigRemove:DB$ RemoveCounterAll | CounterType$ REPAIR | CounterNum$ 1 | ValidCards$ Card.Starship+YouOwn | ValidZone$ Graveyard
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | TriggerZones$ Battlefield | Execute$ TrigRemove | IsPresent$ Card.counters_GE1_REPAIR | PresentZone$ Graveyard | TriggerDescription$ At the beginning of your upkeep, remove an additional repair counter from each card in your graveyard.
+SVar:TrigRemove:DB$ RemoveCounterAll | CounterType$ REPAIR | CounterNum$ 1 | ValidCards$ Card.YouOwn | ValidZone$ Graveyard
 
-S:Mode$ Continuous | EffectZone$ Battlefield | AffectedZone$ Battlefield,Graveyard | Affected$ Creature.Starship+YouCtrl,Card.Starship | AddTrigger$ OnDeath | AddSVar$ TrigRepair
-S:Mode$ Continuous | EffectZone$ Battlefield | AffectedZone$ Battlefield,Graveyard | Affected$ Creature.Starship+YouCtrl,Card.Starship | AddTrigger$ RepairUpkeep | AddSVar$ RepairCount
-S:Mode$ Continuous | EffectZone$ Battlefield | AffectedZone$ Battlefield,Graveyard | Affected$ Creature.Starship+YouCtrl,Card.Starship | AddTrigger$ RepairFinal | AddSVar$ DBRepairRemove
-S:Mode$ Continuous | EffectZone$ Battlefield | AffectedZone$ Battlefield,Graveyard | Affected$ Creature.Starship+YouCtrl,Card.Starship | AddSVar$ DBRepairCast
-S:Mode$ Continuous | EffectZone$ Battlefield | AffectedZone$ Battlefield,Graveyard | Affected$ Creature.Starship+YouCtrl,Card.Starship | AddSVar$ STRepairCast
-SVar:OnDeath:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put six repair counters on it.
+S:Mode$ Continuous | EffectZone$ Battlefield | AffectedZone$ Battlefield,Graveyard | Affected$ Creature.Starship+Droid+YouCtrl,Card.Starship+Droid | AddTrigger$ OnDeath
+S:Mode$ Continuous | EffectZone$ Battlefield | AffectedZone$ Battlefield,Graveyard | Affected$ Creature.Starship+nonDroid+YouCtrl,Card.Starship+nonDroid | AddTrigger$ OnDeath & RepairUpkeep & RepairFinal
+SVar:OnDeath:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | OptionalDecider$ You | TriggerDescription$ When CARDNAME dies, you may put six repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 6 | Defined$ TriggeredCard
-SVar:RepairUpkeep:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ DBRepairRemove | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
+SVar:RepairUpkeep:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ DBRepairRemove | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
 SVar:DBRepairRemove:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
-SVar:RepairCount:Count$CardCounters.REPAIR
 SVar:RepairFinal:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBRepairCast | TriggerDescription$ When the last repair counter is removed, you may cast CARDNAME until end of turn.
 SVar:DBRepairCast:DB$ Effect | StaticAbilities$ STRepairCast | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn
 SVar:STRepairCast:Mode$ Continuous | MayPlay$ True | Affected$ Card.IsRemembered | AffectedZone$ Graveyard | Description$ Until end of turn, you may play EFFECTSOURCE.

--- a/SWTG/custom/cards/SWTG/m/millennium_falcon.txt
+++ b/SWTG/custom/cards/SWTG/m/millennium_falcon.txt
@@ -6,8 +6,7 @@ PT:5/4
 K:Flash
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/m/mon_calamari_cruiser.txt
+++ b/SWTG/custom/cards/SWTG/m/mon_calamari_cruiser.txt
@@ -4,8 +4,7 @@ Types:Artifact Creature Starship
 PT:4/4
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/n/n-1_starfighter.txt
+++ b/SWTG/custom/cards/SWTG/n/n-1_starfighter.txt
@@ -4,8 +4,7 @@ Types:Artifact Creature Starship
 PT:2/2
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/n/nebulon-b_frigate.txt
+++ b/SWTG/custom/cards/SWTG/n/nebulon-b_frigate.txt
@@ -4,8 +4,7 @@ Types:Artifact Creature Starship
 PT:4/2
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/p/probe_droid.txt
+++ b/SWTG/custom/cards/SWTG/p/probe_droid.txt
@@ -8,8 +8,7 @@ SVar:TrigReveal:DB$ RevealHand | ValidTgts$ Player | TgtPrompt$ Select a player 
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put three repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 3 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed, you may cast CARDNAME until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/r/republic_frigate.txt
+++ b/SWTG/custom/cards/SWTG/r/republic_frigate.txt
@@ -4,8 +4,7 @@ Types:Artifact Creature Starship
 PT:3/3
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/r/rocket_trooper.txt
+++ b/SWTG/custom/cards/SWTG/r/rocket_trooper.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Human Trooper
 PT:2/2
 
-S:Mode$ Continuous | Affected$ Creature.Trooper+YouCtrl | AddTrigger$ TrigRocket | Description$ Trooper creatures you control have "Whenever this creature enters, it deals 1 damage to target creature an opponent controls."
+S:Mode$ Continuous | Affected$ Card.Creature+Trooper+YouCtrl | AddTrigger$ TrigRocket | Description$ Trooper creatures you control have "Whenever this creature enters, it deals 1 damage to target creature an opponent controls."
 SVar:TrigRocket:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ DBPing | TriggerDescription$ Whenever this creature enters, it deals 1 damage to target creature an opponent controls.
 SVar:DBPing:DB$ DealDamage | NumDmg$ 1 | ValidTgts$ Creature.OppCtrl | TgtPrompt$ Select target creature an opponent controls
 

--- a/SWTG/custom/cards/SWTG/s/security_droid.txt
+++ b/SWTG/custom/cards/SWTG/s/security_droid.txt
@@ -8,8 +8,7 @@ SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_1_1_a_droid | TokenOw
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put three repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 3 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed from this card, you may cast it until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/s/slave_i.txt
+++ b/SWTG/custom/cards/SWTG/s/slave_i.txt
@@ -6,8 +6,7 @@ PT:3/3
 K:First Strike
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/s/star_destroyer.txt
+++ b/SWTG/custom/cards/SWTG/s/star_destroyer.txt
@@ -4,8 +4,7 @@ Types:Artifact Creature Starship
 PT:6/6
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/s/super_battle_droid.txt
+++ b/SWTG/custom/cards/SWTG/s/super_battle_droid.txt
@@ -5,8 +5,7 @@ PT:4/5
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put two repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 2 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter. When the last is removed, you may cast it from your graveyard until end of turn.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter. When the last is removed, you may cast it from your graveyard until end of turn.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed from this card, you may cast it until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/t/tank_droid.txt
+++ b/SWTG/custom/cards/SWTG/t/tank_droid.txt
@@ -11,8 +11,7 @@ SVar:TrigToken:DB$ Token | TokenAmount$ 1 | TokenScript$ c_1_1_a_droid | TokenOw
 
 T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put three repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 3 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed from this card, you may cast it until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/t/tie_bomber.txt
+++ b/SWTG/custom/cards/SWTG/t/tie_bomber.txt
@@ -4,8 +4,7 @@ Types:Artifact Creature Starship
 PT:3/2
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/t/tie_interceptor.txt
+++ b/SWTG/custom/cards/SWTG/t/tie_interceptor.txt
@@ -4,8 +4,7 @@ Types:Artifact Creature Starship
 PT:1/1
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/t/trade_federation_battleship.txt
+++ b/SWTG/custom/cards/SWTG/t/trade_federation_battleship.txt
@@ -4,8 +4,7 @@ Types:Artifact Creature Starship
 PT:0/6
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/t/tri-fighter.txt
+++ b/SWTG/custom/cards/SWTG/t/tri-fighter.txt
@@ -4,15 +4,13 @@ Types:Artifact Creature Droid Starship
 PT:2/2
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 
-T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | TriggerDescription$ When CARDNAME dies, put three repair counters on it.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigRepair | OptionalDecider$ You | TriggerDescription$ When CARDNAME dies, you may put three repair counters on it.
 SVar:TrigRepair:DB$ PutCounter | CounterType$ REPAIR | CounterNum$ 3 | Defined$ TriggeredCard
-T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | ValidCard$ Card.Self+inGraveyard | CheckSVar$ RepairCount | SVarCompare$ GE1 | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
-SVar:RepairCount:Count$CardCounters.REPAIR
+T:Mode$ Phase | Phase$ Upkeep | ValidPlayer$ You | IsPresent$ Card.Self+counters_GE1_REPAIR | PresentZone$ Graveyard | Execute$ TrigRemoveRepair | TriggerDescription$ At the beginning of your upkeep, if CARDNAME is in your graveyard with repair counters, remove a repair counter.
 SVar:TrigRemoveRepair:DB$ RemoveCounter | CounterType$ REPAIR | CounterNum$ 1 | Defined$ Self
 T:Mode$ CounterRemoved | TriggerZones$ Graveyard | ValidCard$ Card.Self | CounterType$ REPAIR | NewCounterAmount$ 0 | Execute$ DBCast | TriggerDescription$ When the last repair counter is removed from this card, you may cast it until end of turn.
 SVar:DBCast:DB$ Effect | StaticAbilities$ STPlay | ForgetOnMoved$ Graveyard | RememberObjects$ Self | Duration$ EndOfTurn

--- a/SWTG/custom/cards/SWTG/t/trooper_armor.txt
+++ b/SWTG/custom/cards/SWTG/t/trooper_armor.txt
@@ -9,4 +9,4 @@ SVar:TrigAttach:DB$ Attach | Defined$ TriggeredCardLKICopy
 
 K:Equip:2
 
-Oracle:Equipped creature gets +1/+1 and is a Trooper in addition to its other types.\nWhenever a Trooper enters under your control, you may attach Underworld Slums to it.\nEquip {2}
+Oracle:Equipped creature gets +1/+1 and is a Trooper in addition to its other types.\nWhenever a Trooper enters under your control, you may attach Trooper Armor to it.\nEquip {2}

--- a/SWTG/custom/cards/SWTG/v/v-wing.txt
+++ b/SWTG/custom/cards/SWTG/v/v-wing.txt
@@ -6,8 +6,7 @@ PT:1/2
 K:Haste
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/x/x-wing.txt
+++ b/SWTG/custom/cards/SWTG/x/x-wing.txt
@@ -4,8 +4,7 @@ Types:Artifact Creature Rebel Starship
 PT:2/2
 
 K:Spaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 

--- a/SWTG/custom/cards/SWTG/y/y-wing.txt
+++ b/SWTG/custom/cards/SWTG/y/y-wing.txt
@@ -5,8 +5,7 @@ PT:2/3
 
 K:Spaceflight
 
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight
-S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockBySpaceflight
+S:Mode$ Continuous | EffectZone$ Battlefield | Affected$ Card.Self+withSpaceflight | AddStaticAbility$ BlockSpaceflight & BlockBySpaceflight
 SVar:BlockSpaceflight:Mode$ CantBlockBy | ValidAttacker$ Creature.withoutSpaceflight | ValidBlocker$ Creature.Self | Description$ CARDNAME can block only creatures with spaceflight.
 SVar:BlockBySpaceflight:Mode$ CantBlockBy | ValidBlocker$ Creature.withoutSpaceflight+withoutSpacereach | ValidAttacker$ Creature.Self | Description$ CARDNAME can be blocked only by creatures with spaceflight.
 


### PR DESCRIPTION
- Spaceflight - Optimized script by reducing needed continuous static abilities to activate Spaceflight.
- Repair - Now correctly detects card in graveyard and no longer needs to check a separate SVar.
- Maintenance Hangar and Tri-Wing interaction patched to avoid multiple redundant triggers. Maintenance Hanger now only triggers on upkeep if there is a card in graveyard with Repair counters.
- Jedi Knight - added Knight subtype in accordance with the card's oracle.
- Jungle Village, Lightsaber, Trooper Armor - Corrected oracle text.
- Rocket Trooper - Now properly grants Trooper cards that etb their ping effect, including itself.