### PR TITLE
Fixed Monstrosity cost reduction for 07.10 Snapshot

### DIFF
--- a/SWTG/custom/cards/SWTG/n/nerf_herder.txt
+++ b/SWTG/custom/cards/SWTG/n/nerf_herder.txt
@@ -3,7 +3,7 @@ ManaCost:2 G
 Types:Creature Human
 PT:2/3
 
-S:Mode$ ReduceCost | ValidSA$ Activated.Monstrous | Activator$ You | Type$ Ability | Amount$ 1 | Condition$ PlayerTurn | Description$ Monstrosity abilities you activate cost {1} less to activate.
+S:Mode$ ReduceCost | ValidCard$ Card | ValidSpell$ Activated.Monstrosity | Activator$ You | Amount$ 1 | Description$ Monstrosity abilities you activate cost {1} less to activate.
 
 S:Mode$ Continuous | Affected$ Creature.YouCtrl+counters_GE1_P1P1 | AddKeyword$ Trample | Description$ Each creature you control with a +1/+1 counter on it has trample.
 

--- a/SWTG/custom/cards/SWTG/w/weequay_beastmaster.txt
+++ b/SWTG/custom/cards/SWTG/w/weequay_beastmaster.txt
@@ -3,7 +3,7 @@ ManaCost:1 R
 Types:Creature Weequay Shaman
 PT:2/1
 
-S:Mode$ ReduceCost | ValidSA$ Activated.Monstrous | Activator$ You | Type$ Ability | Amount$ 1 | Condition$ PlayerTurn | Description$ Monstrosity abilities you activate cost {1} less to activate.
+S:Mode$ ReduceCost | ValidCard$ Card | ValidSpell$ Activated.Monstrosity | Activator$ You | Amount$ 1 | Description$ Monstrosity abilities you activate cost {1} less to activate.
 
 T:Mode$ BecomeMonstrous | ValidCard$ Creature.YouCtrl | TriggerZones$ Battlefield | Execute$ TrigExtraCounter | TriggerDescription$ Whenever a creature you control becomes monstrous, put an additional +1/+1 counter on that creature.
 SVar:TrigExtraCounter:DB$ PutCounter | CounterType$ P1P1 | CounterNum$ 1 | Defined$ TriggeredCard


### PR DESCRIPTION
Used standard method for cost reduction on activated Monstrosity ability. Supported in 
Forge 2.0.14 SNAPSHOT 07.09 onward.