### PR TITLE
Bantha Herd and Sabacc Game fixes

### DIFF
--- a/SWTG/custom/cards/SWTG/b/bantha_herd.txt
+++ b/SWTG/custom/cards/SWTG/b/bantha_herd.txt
@@ -3,12 +3,12 @@ ManaCost:1 W W
 Types:Creature Beast
 PT:2/2
 
-A:AB$ PutCounter | Cost$ X W W | Monstrosity$ X
+A:AB$ PutCounter | Cost$ X W W | Monstrosity$ X | SubAbility$ StoreX
+SVar:StoreX:DB$ StoreSVar | SVar$ MonstrosityX | Type$ Calculate | Expression$ X
+SVar:X:Count$xPaid
 
 T:Mode$ BecomeMonstrous | ValidCard$ Card.Self | TriggerZones$ Battlefield | Execute$ TrigToken | TriggerDescription$ When this creature becomes monstrous, create X 1/1 white Tusken Raider creature tokens.
 SVar:TrigToken:DB$ Token | TokenAmount$ MonstrosityX | TokenScript$ w_1_1_tusken_raider
-SVar:X:Count$xPaid
-SVar:MonstrosityX:TriggerCount$MonstrosityAmount
 
 Oracle:{X}{W}{W}: Monstrosity X. (If this creature isn't monstrous, put X +1/+1 counters on it and it becomes monstrous.)\nWhen this creature becomes monstrous, create X 1/1 white Tusken Raider creature tokens.
 

--- a/SWTG/custom/cards/SWTG/s/sabacc_game.txt
+++ b/SWTG/custom/cards/SWTG/s/sabacc_game.txt
@@ -5,7 +5,7 @@ Types:Sorcery
 A:SP$ Pump | ValidTgts$ Permanent.OppCtrl | TgtPrompt$ Choose a permanent an opponent controls | RememberObjects$ Targeted | SubAbility$ ChooseOurs | SpellDescription$ Choose target permanent an opponent controls. That opponent chooses a permanent you control. Flip a coin. If you win the flip, gain control of the permanent you chose. If you lose the flip, your opponent gains control of the permanent they chose.
 SVar:ChooseOurs:DB$ ChooseCard | Defined$ RememberedController | Choices$ Permanent.YouCtrl | Mandatory$ True | SubAbility$ DBPump
 SVar:DBPump:DB$ Pump | Defined$ ChosenCard | ImprintCards$ ChosenCard | SubAbility$ DoFlip
-SVar:DoFlip:DB$ FlipACoin | WinSubAbility$ GainOppoPerm | LoseSubAbility$ GainYourPerm
+SVar:DoFlip:DB$ FlipCoin | WinSubAbility$ GainOppoPerm | LoseSubAbility$ GainYourPerm
 SVar:GainOppoPerm:DB$ GainControl | Defined$ Remembered
 SVar:GainYourPerm:DB$ GainControl | Defined$ ChosenCard | NewController$ RememberedController
 


### PR DESCRIPTION
Fix Bantha Herd not making tokens when it becomes monstrous.

Sabacc Game updated flip coin ability.